### PR TITLE
Avoid warnings for assigned but unused variable

### DIFF
--- a/lib/Qt4.rb
+++ b/lib/Qt4.rb
@@ -1,5 +1,5 @@
 windows = false
-processor, platform, *rest = RUBY_PLATFORM.split("-")
+platform = RUBY_PLATFORM.split("-")[1]
 windows = true if platform == 'mswin32' or platform == 'mingw32'
 
 module Qt


### PR DESCRIPTION
The variables `processor` and `rest` are never used and cause warnings in 1.9.3.
