### PR TITLE
cmake missing RUBY_LIBRARY fix

### DIFF
--- a/ext/cmake/modules/FindRuby.cmake
+++ b/ext/cmake/modules/FindRuby.cmake
@@ -197,7 +197,7 @@ ENDIF( ${Ruby_FIND_VERSION_SHORT_NODOT} GREATER 18  OR  ${_RUBY_VERSION_SHORT_NO
 
 
 # Determine the list of possible names for the ruby library
-SET(_RUBY_POSSIBLE_LIB_NAMES ruby ruby-static ruby${_RUBY_VERSION_SHORT} ruby-${RUBY_VERSION})
+SET(_RUBY_POSSIBLE_LIB_NAMES ruby ruby-static ruby${_RUBY_VERSION_SHORT} ruby${_RUBY_VERSION_SHORT_NODOT} ruby-${RUBY_VERSION})
 
 IF(WIN32)
    SET( _RUBY_MSVC_RUNTIME "" )


### PR DESCRIPTION
On Gentoo Linux Ruby library is in /usr/lib/libruby19.so
