### PR TITLE
updated changes to work with ruby 2.0

### DIFF
--- a/ext/ruby/qtruby/src/qtruby.cpp
+++ b/ext/ruby/qtruby/src/qtruby.cpp
@@ -1391,11 +1391,14 @@ qt_signal(int argc, VALUE * argv, VALUE self)
 		return Qfalse;
 	}
 
-#if RUBY_VERSION >= 0x10900
+#if RUBY_VERSION >= 0x20000
+	QLatin1String signalname(rb_id2name(rb_frame_this_func()));
+#elif RUBY_VERSION >= 0x10900
 	QLatin1String signalname(rb_id2name(rb_frame_callee()));
 #else
 	QLatin1String signalname(rb_id2name(rb_frame_last_func()));
 #endif
+
 	VALUE metaObject_value = rb_funcall(qt_internal_module, rb_intern("getMetaObject"), 2, Qnil, self);
 
 	smokeruby_object *ometa = value_obj_info(metaObject_value);


### PR DESCRIPTION
Thanks to jamesrf999 on #issue 55 for finding this to make signals work with the new version of ruby.

I have manually tested this on ubuntu 13.04 and qtbinding 4.8.3 with ruby 2.0 and rvm.  

It may need more testing but I did run the rake examples and they worked fine.
