### PR TITLE
Fixed Qt::RubyThreadFix error

### DIFF
--- a/lib/Qt4.rb
+++ b/lib/Qt4.rb
@@ -3,6 +3,7 @@ platform = RUBY_PLATFORM.split("-")[1]
 windows = true if platform =~ /mswin32/ or platform =~ /mingw32/
 
 begin
+  require 'thread'
   require 'qtbindings-qt'
 rescue LoadError
   # Oh well - Hopefully not using the Windows binary gem


### PR DESCRIPTION
This pull request is a fix for the error which requires individual programs to include "require 'thread'", such as seen in rbqtapi and various other programs:

```
/var/lib/gems/1.9.1/gems/qtbindings-4.8.5.2/lib/Qt4.rb:30:in `const_missing': uninitialized constant Qt::RubyThreadFix::Queue (NameError)
    from /var/lib/gems/1.9.1/gems/qtbindings-4.8.5.2/lib/Qt4.rb:30:in `<class:RubyThreadFix>'
    from /var/lib/gems/1.9.1/gems/qtbindings-4.8.5.2/lib/Qt4.rb:26:in `<module:Qt>'
    from /var/lib/gems/1.9.1/gems/qtbindings-4.8.5.2/lib/Qt4.rb:25:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /var/lib/gems/1.9.1/gems/qtbindings-4.8.5.2/bin/rbqtapi:6:in `<top (required)>'
    from /usr/local/bin/rbqtapi:23:in `load'
    from /usr/local/bin/rbqtapi:23:in `<main>'
```
