### PR TITLE
fix #qt_methods on anonymous classes

### DIFF
--- a/lib/Qt/qtruby4.rb
+++ b/lib/Qt/qtruby4.rb
@@ -3218,6 +3218,7 @@ class Module
     klass = self
     classid = Qt::Internal::ModuleIndex.new(0, 0)
     loop do
+      next if !klass.name
       classid = Qt::Internal::find_pclassid(klass.name)
       break if classid.index
 


### PR DESCRIPTION
Anonymous classes have a name that's nil, and #qt_methods
will bail out on them (because of find_pclassid). This breaks
core Ruby methods as e.g. instance_methods, to reproduce:

```
Class.new.instance_methods
```
