### PR TITLE
Rename rb_str_catf to qt_rb_str_catf to avoid a name collision within…

### DIFF
--- a/ext/ruby/qtruby/src/Qt.cpp
+++ b/ext/ruby/qtruby/src/Qt.cpp
@@ -497,7 +497,6 @@ InvokeNativeSlot::cleanup()
 
 }
 
-/*
 VALUE qt_rb_str_catf(VALUE self, const char *format, ...)
 {
 #define CAT_BUFFER_SIZE 2048
@@ -510,7 +509,7 @@ static char p[CAT_BUFFER_SIZE];
 	va_end(ap);
 	return self;
 }
-*/
+
 const char *
 resolve_classname(smokeruby_object * o)
 {

--- a/ext/ruby/qtruby/src/Qt.cpp
+++ b/ext/ruby/qtruby/src/Qt.cpp
@@ -497,7 +497,8 @@ InvokeNativeSlot::cleanup()
 
 }
 
-VALUE rb_str_catf(VALUE self, const char *format, ...)
+/*
+VALUE qt_rb_str_catf(VALUE self, const char *format, ...)
 {
 #define CAT_BUFFER_SIZE 2048
 static char p[CAT_BUFFER_SIZE];
@@ -509,7 +510,7 @@ static char p[CAT_BUFFER_SIZE];
 	va_end(ap);
 	return self;
 }
-
+*/
 const char *
 resolve_classname(smokeruby_object * o)
 {
@@ -1312,16 +1313,16 @@ VALUE prettyPrintMethod(Smoke::Index id)
     VALUE r = rb_str_new2("");
     const Smoke::Method &meth = qtcore_Smoke->methods[id];
     const char *tname = qtcore_Smoke->types[meth.ret].name;
-    if(meth.flags & Smoke::mf_static) rb_str_catf(r, "static ");
-    rb_str_catf(r, "%s ", (tname ? tname:"void"));
-    rb_str_catf(r, "%s::%s(", qtcore_Smoke->classes[meth.classId].className, qtcore_Smoke->methodNames[meth.name]);
+    if(meth.flags & Smoke::mf_static) qt_rb_str_catf(r, "static ");
+    qt_rb_str_catf(r, "%s ", (tname ? tname:"void"));
+    qt_rb_str_catf(r, "%s::%s(", qtcore_Smoke->classes[meth.classId].className, qtcore_Smoke->methodNames[meth.name]);
     for(int i = 0; i < meth.numArgs; i++) {
-	if(i) rb_str_catf(r, ", ");
+	if(i) qt_rb_str_catf(r, ", ");
 	tname = qtcore_Smoke->types[qtcore_Smoke->argumentList[meth.args+i]].name;
-	rb_str_catf(r, "%s", (tname ? tname:"void"));
+	qt_rb_str_catf(r, "%s", (tname ? tname:"void"));
     }
-    rb_str_catf(r, ")");
-    if(meth.flags & Smoke::mf_const) rb_str_catf(r, " const");
+    qt_rb_str_catf(r, ")");
+    if(meth.flags & Smoke::mf_const) qt_rb_str_catf(r, " const");
     return r;
 }
 }

--- a/ext/ruby/qtruby/src/qtruby.cpp
+++ b/ext/ruby/qtruby/src/qtruby.cpp
@@ -2121,27 +2121,27 @@ dumpCandidates(VALUE /*self*/, VALUE rmeths)
 	if(rmeths != Qnil) {
 	int count = RARRAY_LEN(rmeths);
 		for(int i = 0; i < count; i++) {
-		rb_str_catf(errmsg, "\t");
+		qt_rb_str_catf(errmsg, "\t");
 		int id = NUM2INT(rb_funcall(rb_ary_entry(rmeths, i), rb_intern("index"), 0));
 		Smoke* smoke = smokeList[NUM2INT(rb_funcall(rb_ary_entry(rmeths, i), rb_intern("smoke"), 0))];
 		const Smoke::Method &meth = smoke->methods[id];
 		const char *tname = smoke->types[meth.ret].name;
 		if(meth.flags & Smoke::mf_enum) {
-			rb_str_catf(errmsg, "enum ");
-			rb_str_catf(errmsg, "%s::%s", smoke->classes[meth.classId].className, smoke->methodNames[meth.name]);
-			rb_str_catf(errmsg, "\n");
+			qt_rb_str_catf(errmsg, "enum ");
+			qt_rb_str_catf(errmsg, "%s::%s", smoke->classes[meth.classId].className, smoke->methodNames[meth.name]);
+			qt_rb_str_catf(errmsg, "\n");
 		} else {
-			if(meth.flags & Smoke::mf_static) rb_str_catf(errmsg, "static ");
-			rb_str_catf(errmsg, "%s ", (tname ? tname:"void"));
-			rb_str_catf(errmsg, "%s::%s(", smoke->classes[meth.classId].className, smoke->methodNames[meth.name]);
+			if(meth.flags & Smoke::mf_static) qt_rb_str_catf(errmsg, "static ");
+			qt_rb_str_catf(errmsg, "%s ", (tname ? tname:"void"));
+			qt_rb_str_catf(errmsg, "%s::%s(", smoke->classes[meth.classId].className, smoke->methodNames[meth.name]);
 			for(int i = 0; i < meth.numArgs; i++) {
-			if(i) rb_str_catf(errmsg, ", ");
+			if(i) qt_rb_str_catf(errmsg, ", ");
 			tname = smoke->types[smoke->argumentList[meth.args+i]].name;
-			rb_str_catf(errmsg, "%s", (tname ? tname:"void"));
+			qt_rb_str_catf(errmsg, "%s", (tname ? tname:"void"));
 			}
-			rb_str_catf(errmsg, ")");
-			if(meth.flags & Smoke::mf_const) rb_str_catf(errmsg, " const");
-			rb_str_catf(errmsg, "\n");
+			qt_rb_str_catf(errmsg, ")");
+			if(meth.flags & Smoke::mf_const) qt_rb_str_catf(errmsg, " const");
+			qt_rb_str_catf(errmsg, "\n");
 			}
 		}
 	}

--- a/ext/ruby/qtruby/src/qtruby.h
+++ b/ext/ruby/qtruby/src/qtruby.h
@@ -159,7 +159,7 @@ extern Q_DECL_EXPORT void mapPointer(VALUE obj, smokeruby_object *o, Smoke::Inde
 extern Q_DECL_EXPORT void unmapPointer(smokeruby_object *, Smoke::Index, void*);
 
 extern Q_DECL_EXPORT const char * resolve_classname(smokeruby_object * o);
-extern Q_DECL_EXPORT VALUE rb_str_catf(VALUE self, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
+extern Q_DECL_EXPORT VALUE qt_rb_str_catf(VALUE self, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
 
 extern Q_DECL_EXPORT VALUE findMethod(VALUE self, VALUE c_value, VALUE name_value);
 extern Q_DECL_EXPORT VALUE findAllMethods(int argc, VALUE * argv, VALUE self);


### PR DESCRIPTION
… Ruby itself.

Not sure why but on Ubuntu 12.04 and Ruby 2.2.2 I get a name collision with rb_str_catf. 
On Ubuntu 14.04 with the same version of ruby no name collision.
The version of Qt are very slightly different I think but that would not affect this particular name collision.

However this patch fixes it for 12.04 and still works on 14.04. 
It seems it should work for most versions.

What is even more strange is that if I comment out that entire rb_str_catf  function it still builds and runs, so maybe it is not even used anywhere, which may explain why it compiles on 14.04 and not 12.04 as the compiler versions are different, and one my be upset about the name collision and the other is clever enough to see the function is never used anyway.

Full disclaimer I found a similar patch with a google for rb_str_catf qtbindings, however it seems that patch never made it into upstream.
