### PR TITLE
 added std=c++03 compiler fallback due to smoke errors on ubuntu16.04/gcc5

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,5 +1,13 @@
 project(qtbind)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CXXVERSION ${CMAKE_CXX_COMPILER_VERSION}) 
+    if((CXXVERSION VERSION_GREATER 4) AND (CXXVERSION VERSION_LESS 6)) 
+        message(WARNING "changing compile standard to c++03 due to gcc 5 incompabilities")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+    endif()
+endif()
+
 add_subdirectory(generator)
 
 # where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked


### PR DESCRIPTION
I added a check for gcc version 5 to change the g++ compiler std back to c++03. This is because on machines with e.g. ubuntu 16.04 using gcc5  smoke produces some errors with virtual inherited destructors. For further compabilities, this package should therefore be self-configuring with c++03 std.