### PR TITLE
Fixed build badge in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![qtbindings Version](https://badge.fury.io/rb/qtbindings.svg)](https://badge.fury.io/rb/qtbindings)
 [![qtbindings-qt Version](https://badge.fury.io/rb/qtbindings-qt.svg)](https://badge.fury.io/rb/qtbindings-qt)
-![Ruby](https://github.com/Lykos/qtbindings/workflows/Ruby/badge.svg)
+![Ruby](https://github.com/ryanmelt/qtbindings/workflows/Ruby/badge.svg)
 
 Note: The current windows gem (since 4.8.6.4) only works with Ruby 2.4 and Ruby 2.5.  To use Ruby 2.0 to Ruby 2.3 please install version 4.8.6.3
 


### PR DESCRIPTION
The badge was linking to my forked repo. This way, it was working fine innthe forked repo. But it was broken after the merge. Now it should be fixed.